### PR TITLE
Remove one second wait when resolving ready state

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -261,9 +261,7 @@
           });
           return new Promise(function(resolve) {
             // Wait for window to stop rendering
-            setTimeout(function() {
-              return window.requestAnimationFrame(resolve);
-            }, 1000);
+            return window.requestAnimationFrame(resolve);
           });
         });
       });


### PR DESCRIPTION
Needs to be propagated to `formio-files-core`; should coincide with the release of formio/formio-files-core#11 and formio/formio.js#1491.