### PR TITLE
Fix [webpack-cli] Error: error:0308010C:digital envelope routines::unsupported when running "npm run build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@
 ##                                                   ##
 #######################################################
 
-FROM formio/formio-files-core
-COPY ./dist /app/node_modules/formio-viewer/dist/
+FROM formio/pdf-server:5.5.2-rc.1
+COPY ./dist /src/node_modules/formio-viewer/dist/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     environment: {
       arrowFunction: false
     },
+    hashFunction: "sha512"
   },
   plugins: [
     new webpack.IgnorePlugin({


### PR DESCRIPTION
- ``npm run build`` will throw an error due to node.js fixing security issue with SSL provider in Node.js v17
- Specifying the ``hashFunction`` in the webpack.config file fixes this issue
- see [stackoverflow](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported)