### PR TITLE
FIO-9922: fixed an issue where printed pdf looks bigger

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -199,6 +199,12 @@
                 transform: rotate(359deg);
             }
         }
+
+        @media print {
+          @page {
+            size: a3
+          }
+        }
     </style>
     <style id="premiumStyles"></style>
     <script id="premiumScript"></script>


### PR DESCRIPTION
Printed PDF looks bigger with 5.x renderer in comparison with 4.x. The reason for it is bootstrap 5. Many styles for '@media print' were removed in Bootstrap 5. So, Bootstrap 4 set the page size to a3 when printing the page, that made the the image look smaller. This PR adds this style to the viewer.